### PR TITLE
Tests: split pathname at last index of test

### DIFF
--- a/test/jquery.js
+++ b/test/jquery.js
@@ -2,7 +2,7 @@
 ( function() {
 	/* global loadTests: false */
 
-	var path = window.location.pathname.split( "test" )[ 0 ],
+	var path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf("test")),
 		QUnit = window.QUnit || parent.QUnit,
 		require = window.require || parent.require,
 


### PR DESCRIPTION
This change fixes issue with tests' path being calculated incorrectly when the string value "test" exists earlier on in the URL by splitting it at the last index of "test", instead of the first. 